### PR TITLE
Endpoint POST /telemetry

### DIFF
--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,5 +1,5 @@
 # Port on which the Uvicorn server will listen
 PORT = 8081
 # Refresh interval for simulator data (in milliseconds)
-REFRESHINTERVAL = 1000
+REFRESH_INTERVAL = 1000
 

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -1,0 +1,5 @@
+# Port on which the Uvicorn server will listen
+PORT = 8081
+# Refresh interval for simulator data (in milliseconds)
+REFRESHINTERVAL = 1000
+

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from config import *
+
+app = FastAPI()
+
+latest_packet = {}
+
+
+# Endpoint to receive data from the simulator
+# Requires a POST method and returns HTTP status 201 on success
+@app.post("/telemetry", status_code=201)
+async def receive_packet(data: dict):
+    global latest_packet
+    latest_packet = data
+    print(latest_packet)
+    return {"status": "received"}

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -1,8 +1,9 @@
 from fastapi import FastAPI
-from config import *
+from config import PORT
 
 app = FastAPI()
-
+# Stores the most recently received telemetry packet in memory.
+# Overwritten with every new packet. Lost on server restart.
 latest_packet = {}
 
 


### PR DESCRIPTION

Added the POST /telemetry endpoint to receive data from the simulator. 

The FastAPI server runs on `port 8081`.